### PR TITLE
resolve a symlink

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -269,7 +269,17 @@ func (o *Options) SetPublicKeyPEM(pembytes []byte) error {
 
 func (o *Options) getPath() (string, error) {
 	if o.TargetPath == "" {
-		return osext.Executable()
+		exe, err := osext.Executable()
+		if err != nil {
+			return "", err
+		}
+
+		exe, err := filepath.EvalSymlinks(exe)
+		if err != nil {
+			return "", err
+		}
+
+		return exe, nil
 	} else {
 		return o.TargetPath, nil
 	}


### PR DESCRIPTION
Current implementation does not consider the case where the target
executable is run via symlink. If the executable is a symlink, it should
replace the linked executable file, not the symlink itself.